### PR TITLE
messages.properties in Swedish (sv-SE or sv)

### DIFF
--- a/static/locales/en/messages.properties
+++ b/static/locales/en/messages.properties
@@ -1,67 +1,67 @@
 # Title tag
-title=Pontoon Intro
+title=Pontoon: Intro
 
 # Navigation
-navigation-toggle=Toggle navigation
-navigation-title=Pontoon Intro
-navigation-what=What
-navigation-how=How
-navigation-more=More
-navigation-developers=Developers
+navigation-toggle=Växla navigering
+navigation-title=Pontoon: Intro
+navigation-what=Vad
+navigation-how=Hur
+navigation-more=Mer
+navigation-developers=Utvecklare
 
 # Header
-upper-title=Pontoon by Mozilla
-headline-1=Localize the web.
-headline-2=In place.
-call-to-action=Tell Me More
+upper-title=Pontoon från Mozilla
+headline-1=Språkanpassa nätet.
+headline-2=På nätet.
+call-to-action=Berätta mer
 
 # What
-what-title=What is Pontoon?
-what-desc=Pontoon allows you to localize web content in place, with context and spatial limitations right in front of you.
-context=Understand context
-context-desc=By localizing web page on the page itself, you no longer need to worry if the word you are translating is a verb or noun.
-space=See spatial limitations
-space-desc=Avoid breaking user interface by seeing how much space is available for your translations, which is especially useful with apps.
-preview=Get instant preview
-preview-desc=The moment you submit translation, it replaces the original text in the web page, making you the first proofreader and tester.
+what-title=Vad är Pontoon?
+what-desc=Pontoon låter dig översätta webbinnehåll på plats, med kontext och platsbegränsningar fullt synliga på skärmen framför dig.
+context=Förstå kontexten
+context-desc=Genom att språkanpassa en webbsida direkt på själva sidan, behöver du inte längre gissa om ordet du översätter är ett verb eller ett substantiv.
+space=Se platsbegränsningar
+space-desc=Du undviker att stöka till användargränssnittet eftersom du kan se hur mycket plats som är tillgänglig för dina översättningar. Särskilt användbart vid översättning av appar.
+preview=Förhandsgranska direkt
+preview-desc=I samma stund som du bekräftar din översättning, så ersätter den originaltexten på webbsidan. Du blir både korrekturläsare och testare.
 
 # How
-how-title=How does it work?
-how-desc=Pontoon is a very simple and intuitive tool that requires little to no technical skill for localizers to use.
-hover=Hover
-hover-sub=over web content
-hover-desc=Move your mouse over headings, links, paragraphs or other text blocks on this page. A dashed rectangle will appear around each of these blocks, marking strings that are available for localization on the page itself.
-select=Select
-select-sub=a text block
-select-desc=A toolbar appears above the dashed rectangle, allowing you to select the corresponding text block for editing. To do so, either click on the Edit button in the toolbar, or double-click anywhere inside the dashed border.
-translate=Translate
-translate-sub=selected text
-translate-desc=When you enter editing mode, the entire text block will be selected. You can start typing your translation immeditely while seeing the exact context of your source string and how much space is available for your translation.
-save=Save
-save-sub=your translation
-save-desc=As soon as you are happy with your translation, you can save it by pressing Enter or clicking the save icon in the toolbar. To quit translation mode without saving changes, press Esc or click the cancel icon in the toolbar.
-profit=Learn more
+how-title=Hur fungerar Pontoon?
+how-desc=Pontoon är ett mycket lättanvänt och intuitivt verktyg, som inte kräver några särskilda tekniska kunskaper för att kunna användas av översättare.
+hover=Hovra
+hover-sub=över webbinnehåll
+hover-desc=För din muspekare över rubriker, länkar, stycken eller andra textavsnitt på den här webbsidan. En streckad rektangel kommer att visa sig kring vart och ett av dessa avsnitt och märker på så sätt ut de strängar, som är tillgängliga för översättning på själva sidan.
+select=Markera
+select-sub=ett textavsnitt
+select-desc=Det finns ett verktygsfält på ovansidan av den streckade rektangeln, som låter dig markera textavsnittet för redigering. För att göra det klickar du på redigeringsknappen i verktygsfältet eller dubbelklickar varsomhelst inom den streckade kantlinjen.
+translate=Översätt
+translate-sub=den markerade texten
+translate-desc=När du övergår till redigeringsläget kommer hela textavsnittet att markeras. Du kan börja skriva in din översättning direkt samtidigt som du ser kontexten för din källsträng och hur mycket plats som finns för din översättning.
+save=Spara
+save-sub=din översättning
+save-desc=Så snart du är nöjd med din översättning kan du spara den genom att trycka på Retur eller klicka på sparikonen i verktygsfältet. För att gå ur översättningsläget utan att spara några ändringar trycker du på Esc eller klickar på avbrytikonen i verktygsfältet.
+profit=Läs mer
 
 # More
-more-title=What else can it do?
-more-desc=Pontoon's in place translation mode is what puts it above others, but it also has many other benefits.
-qa=Quality checks
-qa-desc=Translations are automatically reviewed for quality before saving
-helpers=Translation helpers
-helpers-desc=Get help from translation memory, machine translation and the likes
-plurals=Plurals support
-plurals-desc=Strings with plurals can be translated to all plural forms available in your languge
+more-title=Vad mer kan Pontoon göra?
+more-desc=Pontoons direktöversättningsläge är det som gör att det skiljer ut sig från de andra, men det har också många andra fördelar.
+qa=Kvalitetskontroller
+qa-desc=Översättningar kvalitetsgranskas automatiskt innan de sparas
+helpers=Översättningshjälp
+helpers-desc=Få hjälp via översättningsminne, maskinöversättning och liknande
+plurals=Stöd för pluralformer
+plurals-desc=Strängar med plural kan kan översättas till alla pluralformer som finns i ditt språk
 
 # Developers
-developers-title=Get involved
-developers-desc=Are you a developer, interested in Pontoon? There are plenty of ways to get your hands dirty.
-implement=Enable it on your site
-implement-desc=Add a script and you are halfway through
-github=Hack it on Github
-github-desc=It's completely free and open source
-by-mozilla=By someone you trust
-by-mozilla-desc=Developed by the non-profit behind Firefox
+developers-title=Engagera dig
+developers-desc=Är du en utvecklare, som är intresserad av Pontoon? Det finns massor av sätt för dig att få skit under naglarna.
+implement=Använd Pontoon på din webbplats
+implement-desc=Lägg till ett skript, så är du halvvägs
+github=Hacka Pontoon på Github
+github-desc=Det är helt gratis och har öppen källkod
+by-mozilla=Från en du litar på
+by-mozilla-desc=Utvecklat av den ideella organisationen bakom Firefox
 
 # Footer
-author=Crafted by Mozilla
-join-us=Join us
+author=Utvecklat av Mozilla
+join-us=Gå med i Mozilla


### PR DESCRIPTION
Hi,

I have translated Pontoon to Swedish. Use the locale code sv-SE (Mozilla's standard for Swedish) if the tool automatically sets according to Firefox' locale, but you can use "sv" if that is according to the standard for the tool.

Cheers,

Mikael Hiort af Ornäs
